### PR TITLE
Auto-focus on the password field

### DIFF
--- a/archlinux-simplyblack/Main.qml
+++ b/archlinux-simplyblack/Main.qml
@@ -131,6 +131,17 @@ Rectangle {
                         font.pixelSize: 14
                         tooltipBG: "lightgrey"
 
+                        // This hack courtesy of our friends at KDE: https://quickgit.kde.org/?p=plasma-workspace.git&a=blobdiff&h=275801dc5539a342276e4c9f6817ff3c80f7d020&hp=31423628c9a847344c0e3e27b98b73b6042cefe6&hb=dfc4b8b2a0e2b012f68f0192e29081ee230e8c03&f=lookandfeel%2Fcontents%2Floginmanager%2FMain.qml
+                        // focus works in qmlscene
+                        // but this seems to be needed when loaded from SDDM
+                        // I don't understand why, but we have seen this before in the old lock screen
+                        focus: true
+                        Timer {
+                            interval: 200
+                            running: true
+                            onTriggered: password.forceActiveFocus()
+                        }
+
                         KeyNavigation.backtab: name; KeyNavigation.tab: session
 
                         Keys.onPressed: {

--- a/archlinux-soft-grey/Main.qml
+++ b/archlinux-soft-grey/Main.qml
@@ -131,6 +131,17 @@ Rectangle {
                         font.pixelSize: 14
                         tooltipBG: "lightgrey"
 
+                        // This hack courtesy of our friends at KDE: https://quickgit.kde.org/?p=plasma-workspace.git&a=blobdiff&h=275801dc5539a342276e4c9f6817ff3c80f7d020&hp=31423628c9a847344c0e3e27b98b73b6042cefe6&hb=dfc4b8b2a0e2b012f68f0192e29081ee230e8c03&f=lookandfeel%2Fcontents%2Floginmanager%2FMain.qml
+                        // focus works in qmlscene
+                        // but this seems to be needed when loaded from SDDM
+                        // I don't understand why, but we have seen this before in the old lock screen
+                        focus: true
+                        Timer {
+                            interval: 200
+                            running: true
+                            onTriggered: password.forceActiveFocus()
+                        }
+
                         KeyNavigation.backtab: name; KeyNavigation.tab: session
 
                         Keys.onPressed: {


### PR DESCRIPTION
Borrow a fix from a KDE developer to make it so that the password field
in this theme auto-focuses.

SDDM has a bug where it ignores `focus:true`, so a timer is needed.

You don't have to accept this if you don't want to, but most OS greeters auto-focus, it's a standard feature and very useful to have :smile:
