### PR TITLE
Remove unnecessary focus from PasswordBox

### DIFF
--- a/archlinux-simplyblack/Main.qml
+++ b/archlinux-simplyblack/Main.qml
@@ -133,12 +133,6 @@ Rectangle {
                         width: parent.width * 0.8; height: archlinux.height / 9
                         font.pixelSize: archlinux.height / 20
                         tooltipBG: "lightgrey"
-                        focus: true
-                        Timer {
-                            interval: 200
-                            running: true
-                            onTriggered: password.forceActiveFocus()
-                        }
 
                         KeyNavigation.backtab: name; KeyNavigation.tab: session
 

--- a/archlinux-soft-grey/Main.qml
+++ b/archlinux-soft-grey/Main.qml
@@ -133,12 +133,6 @@ Rectangle {
                         width: parent.width * 0.8; height: archlinux.height / 9
                         font.pixelSize: archlinux.height / 20
                         tooltipBG: "lightgrey"
-                        focus: true
-                        Timer {
-                            interval: 200
-                            running: true
-                            onTriggered: password.forceActiveFocus()
-                        }
 
                         KeyNavigation.backtab: name; KeyNavigation.tab: session
 


### PR DESCRIPTION
Not sure why there is a re-focus on the password box.

It doesn't seem necessary. When you set `RememberLastSession=false` and `RememberLastUser=false` the focus is automatically on the `PasswordBox`, and you want it by default on the username `Text` box.